### PR TITLE
Include PolicyIdentifiers for non Deny/Permit

### DIFF
--- a/openaz-xacml-pdp/pom.xml
+++ b/openaz-xacml-pdp/pom.xml
@@ -40,5 +40,13 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/openaz-xacml-pdp/src/main/java/org/apache/openaz/xacml/pdp/policy/Policy.java
+++ b/openaz-xacml-pdp/src/main/java/org/apache/openaz/xacml/pdp/policy/Policy.java
@@ -310,16 +310,17 @@ public class Policy extends PolicyDef {
             .combine(evaluationContext, ruleCombiningElements, this.getCombinerParameterList());
         assert evaluationResultCombined != null;
 
+        /*
+         * Add my id to the policy identifiers
+         */
+        if (evaluationContext.getRequest().getReturnPolicyIdList()) {
+            evaluationResultCombined.addPolicyIdentifier(this.getIdReference());
+        }
+
         if (evaluationResultCombined.getDecision() == Decision.DENY
             || evaluationResultCombined.getDecision() == Decision.PERMIT) {
             this.updateResult(evaluationResultCombined, evaluationContext);
 
-            /*
-             * Add my id to the policy identifiers
-             */
-            if (evaluationContext.getRequest().getReturnPolicyIdList()) {
-                evaluationResultCombined.addPolicyIdentifier(this.getIdReference());
-            }
         }
         if (evaluationContext.isTracing()) {
             evaluationContext.trace(new StdTraceEvent<Result>("Result", this, evaluationResultCombined));

--- a/openaz-xacml-pdp/src/main/java/org/apache/openaz/xacml/pdp/policy/PolicySet.java
+++ b/openaz-xacml-pdp/src/main/java/org/apache/openaz/xacml/pdp/policy/PolicySet.java
@@ -232,16 +232,17 @@ public class PolicySet extends PolicyDef {
             .combine(evaluationContext, listCombiningElements, getCombinerParameterList());
         assert evaluationResultCombined != null;
 
+        /*
+         * Add my id to the policy set identifiers
+         */
+        if (evaluationContext.getRequest().getReturnPolicyIdList()) {
+            evaluationResultCombined.addPolicySetIdentifier(this.getIdReference());
+        }
+
         if (evaluationResultCombined.getDecision() == Decision.DENY
             || evaluationResultCombined.getDecision() == Decision.PERMIT) {
             this.updateResult(evaluationResultCombined, evaluationContext);
 
-            /*
-             * Add my id to the policy set identifiers
-             */
-            if (evaluationContext.getRequest().getReturnPolicyIdList()) {
-                evaluationResultCombined.addPolicySetIdentifier(this.getIdReference());
-            }
         }
         if (evaluationContext.isTracing()) {
             evaluationContext.trace(new StdTraceEvent<Result>("Result", this, evaluationResultCombined));

--- a/openaz-xacml-pdp/src/test/java/org/apache/openaz/xacml/pdp/policy/PolicySetTest.java
+++ b/openaz-xacml-pdp/src/test/java/org/apache/openaz/xacml/pdp/policy/PolicySetTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+
+package org.apache.openaz.xacml.pdp.policy;
+
+import org.apache.openaz.xacml.api.Decision;
+import org.apache.openaz.xacml.api.IdReference;
+import org.apache.openaz.xacml.api.Request;
+import org.apache.openaz.xacml.api.XACML1;
+import org.apache.openaz.xacml.pdp.eval.EvaluationContext;
+import org.apache.openaz.xacml.pdp.eval.EvaluationException;
+import org.apache.openaz.xacml.pdp.eval.EvaluationResult;
+import org.apache.openaz.xacml.pdp.eval.MatchResult;
+import org.apache.openaz.xacml.pdp.std.combiners.CombiningAlgorithmBase;
+import org.apache.openaz.xacml.std.StdStatusCode;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PolicySetTest extends PolicyTest {
+
+    @Override
+    protected PolicyDef createPolicy() {
+        PolicySet policySet = new PolicySet(StdStatusCode.STATUS_CODE_OK);
+        policySet.addChild(super.createPolicy());
+        policySet.setTarget(createTarget());
+        CombiningAlgorithmBase<PolicySetChild> ruleCombiningAlgorithm = new CombiningAlgorithmBase<PolicySetChild>(XACML1.ID_RULE_COMBINING_ALGORITHM) {
+            @Override
+            public EvaluationResult combine(EvaluationContext evaluationContext, List<CombiningElement<PolicySetChild>> combiningElements, List<CombinerParameter> combinerParameters) throws EvaluationException {
+                return new EvaluationResult(Decision.INDETERMINATE);
+            }
+        };
+        policySet.setPolicyCombiningAlgorithm(ruleCombiningAlgorithm);
+        return policySet;
+    }
+
+    @Override
+    protected Collection<IdReference> getPolicyIdentifiers(EvaluationResult evaluationResult) {
+        return evaluationResult.getPolicySetIdentifiers();
+    }
+}

--- a/openaz-xacml-pdp/src/test/java/org/apache/openaz/xacml/pdp/policy/PolicyTest.java
+++ b/openaz-xacml-pdp/src/test/java/org/apache/openaz/xacml/pdp/policy/PolicyTest.java
@@ -1,0 +1,97 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+
+package org.apache.openaz.xacml.pdp.policy;
+
+import org.apache.openaz.xacml.api.Decision;
+import org.apache.openaz.xacml.api.IdReference;
+import org.apache.openaz.xacml.api.Request;
+import org.apache.openaz.xacml.api.XACML1;
+import org.apache.openaz.xacml.pdp.eval.EvaluationContext;
+import org.apache.openaz.xacml.pdp.eval.EvaluationException;
+import org.apache.openaz.xacml.pdp.eval.EvaluationResult;
+import org.apache.openaz.xacml.pdp.eval.MatchResult;
+import org.apache.openaz.xacml.pdp.std.combiners.CombiningAlgorithmBase;
+import org.apache.openaz.xacml.std.StdStatusCode;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PolicyTest {
+
+    private EvaluationContext evaluationContext;
+
+    @Before
+    public void before() {
+        // Individual tests can override the default behaviour
+        this.evaluationContext = mock(EvaluationContext.class);
+
+        Request request = mock(Request.class);
+        when(evaluationContext.getRequest()).thenReturn(request);
+        when(request.getReturnPolicyIdList()).thenReturn(true);
+    }
+
+    @Test
+    public void testIncludePolicyIdentifierForIndeterminate() throws EvaluationException {
+        PolicyDef policy = createPolicy();
+
+        EvaluationResult evaluationResult = policy.evaluate(evaluationContext);
+
+        Collection<IdReference> policyIdentifiers = getPolicyIdentifiers(evaluationResult);
+
+        assertEquals(1, policyIdentifiers.size());
+        assertEquals(Decision.INDETERMINATE, evaluationResult.getDecision());
+    }
+
+    protected Collection<IdReference> getPolicyIdentifiers(EvaluationResult evaluationResult) {
+        return evaluationResult.getPolicyIdentifiers();
+    }
+
+    protected PolicyDef createPolicy() {
+        Policy policy = new Policy(StdStatusCode.STATUS_CODE_OK);
+        CombiningAlgorithmBase<Rule> ruleCombiningAlgorithm = new CombiningAlgorithmBase<Rule>(XACML1.ID_RULE_COMBINING_ALGORITHM) {
+            @Override
+            public EvaluationResult combine(EvaluationContext evaluationContext, List<CombiningElement<Rule>> combiningElements, List<CombinerParameter> combinerParameters) throws EvaluationException {
+                return new EvaluationResult(Decision.INDETERMINATE);
+
+            }
+        };
+        policy.setRuleCombiningAlgorithm(ruleCombiningAlgorithm);
+        Target target = createTarget();
+        policy.setTarget(target);
+        return policy;
+    }
+
+    protected Target createTarget() {
+        return new Target() {
+                @Override
+                public MatchResult match(EvaluationContext evaluationContext) throws EvaluationException {
+                    return new MatchResult(MatchResult.MatchCode.MATCH);
+                }
+            };
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <version.commons.codec>1.10</version.commons.codec>
         <version.commons.cli>1.3.1</version.commons.cli>
         <version.junit>4.12</version.junit>
+        <version.mockito>1.10.19</version.mockito>
         <version.log4j>1.2.17</version.log4j>
         <version.xmlapi>1.4.01</version.xmlapi>
     </properties>
@@ -197,6 +198,12 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${version.junit}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>1.10.19</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
The Policy and PolicySet will always include the PolicyIdentifiers
when the Request returns true for getReturnPolicyIdList() and not
only when the Decision is Permit or Deny.

This allowes a Policy Enforcement Point to access / log the policy
in case of an Indeterminate.