### PR TITLE
Fix configuration and conformance test policy files

### DIFF
--- a/openaz-xacml-test/src/test/java/org/apache/openaz/xacml/pdp/test/annotations/TestAnnotation.java
+++ b/openaz-xacml-test/src/test/java/org/apache/openaz/xacml/pdp/test/annotations/TestAnnotation.java
@@ -168,13 +168,11 @@ public class TestAnnotation extends TestBase {
 
     };
 
-    @XACMLRequest(Defaults = "http://www.w3.org/TR/1999/Rec-xpath-19991116", multiRequest = @XACMLMultiRequest(values = {
-                                                           @XACMLRequestReference(values = {
-            "subject1", "action", "resource"
-        }), @XACMLRequestReference(values = {
-            "subject2", "action", "resource"
-        })
-                  }))
+    @XACMLRequest(Defaults = "http://www.w3.org/TR/1999/Rec-xpath-19991116",
+            multiRequest = @XACMLMultiRequest(values = {
+                    @XACMLRequestReference(values = {"subject1", "action", "resource"}),
+                    @XACMLRequestReference(values = {"subject2", "action", "resource"})
+            }))
     public class MyMultiRequestAttributes {
 
         @XACMLSubject(id = "subject1")

--- a/openaz-xacml-test/src/test/resources/testsets/annotation/results/Response.000.json
+++ b/openaz-xacml-test/src/test/resources/testsets/annotation/results/Response.000.json
@@ -1,0 +1,1 @@
+{results=[{decision=Indeterminate,status={statusCode={statusCodeValue=urn:oasis:names:tc:xacml:1.0:status:processing-error},statusMessage=No matching root policy found}}]}

--- a/openaz-xacml-test/src/test/resources/testsets/annotation/results/Response.001.json
+++ b/openaz-xacml-test/src/test/resources/testsets/annotation/results/Response.001.json
@@ -1,0 +1,1 @@
+{results=[{decision=Indeterminate,status={statusCode={statusCodeValue=urn:oasis:names:tc:xacml:1.0:status:processing-error},statusMessage=No matching root policy found}}]}

--- a/openaz-xacml-test/src/test/resources/testsets/annotation/results/Response.002.json
+++ b/openaz-xacml-test/src/test/resources/testsets/annotation/results/Response.002.json
@@ -1,0 +1,1 @@
+{results=[{decision=Permit,status={statusCode={statusCodeValue=urn:oasis:names:tc:xacml:1.0:status:ok}}}{decision=Deny,status={statusCode={statusCodeValue=urn:oasis:names:tc:xacml:1.0:status:ok}}}]}

--- a/openaz-xacml-test/src/test/resources/testsets/annotation/xacml.properties
+++ b/openaz-xacml-test/src/test/resources/testsets/annotation/xacml.properties
@@ -4,7 +4,7 @@
 # Standard API Factories
 #
 xacml.dataTypeFactory=org.apache.openaz.xacml.std.StdDataTypeFactory
-xacml.pdpEngineFactory=org.apache.openaz.xacmlatt.pdp.ATTPDPEngineFactory
+xacml.pdpEngineFactory=org.apache.openaz.xacml.pdp.OpenAZPDPEngineFactory
 xacml.pepEngineFactory=org.apache.openaz.xacml.std.pep.StdEngineFactory
 xacml.pipFinderFactory=org.apache.openaz.xacml.std.pip.StdPIPFinderFactory
 xacml.traceEngineFactory=org.apache.openaz.xacml.std.trace.LoggingTraceEngineFactory

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml.properties
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml.properties
@@ -2,7 +2,7 @@
 # Standard API Factories
 #
 xacml.dataTypeFactory=org.apache.openaz.xacml.std.StdDataTypeFactory
-xacml.pdpEngineFactory=org.apache.openaz.xacmlatt.pdp.ATTPDPEngineFactory
+xacml.pdpEngineFactory=org.apache.openaz.xacml.pdp.OpenAZPDPEngineFactory
 xacml.pepEngineFactory=org.apache.openaz.xacml.std.pep.StdEngineFactory
 xacml.pipFinderFactory=org.apache.openaz.xacml.std.pip.StdPIPFinderFactory
 #xacml.traceEngineFactory=org.apache.openaz.xacml.std.trace.LoggingTraceEngineFactory
@@ -16,7 +16,7 @@ xacml.pipFinderFactory=org.apache.openaz.xacml.std.pip.StdPIPFinderFactory
 # engine2.classname=org.apache.openaz.xacmlpip.ActiveDirectoryPIP
 # ...
 xacml.pip.engines=ConformancePIPEngine
-ConformancePIPEngine.classname=org.apache.openaz.xacmlatt.pdp.test.conformance.ConformancePIPEngine
+ConformancePIPEngine.classname=org.apache.openaz.xacml.pdp.test.conformance.ConformancePIPEngine
 ConformancePIPEngine.file=testsets/conformance/xacml3.0-ct-v.0.4/PIP.txt
 
 # OpenAZ PDP Implementation Factories

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA001Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA001Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA1:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA001.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA002Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA002Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA002:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA002.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA003Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA003Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA003:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA003.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA004Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA004Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA1:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA004.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA005Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA005Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA005:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA005.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA006Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA006Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA006:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA006.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA007Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA007Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA007:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA007.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA008Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA008Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA008:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA008.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA009Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA009Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA009:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os       access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA009.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA010Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA010Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA1:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA010.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA011Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA011Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA1:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA011.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA012Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA012Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA1:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA012.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA013Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA013Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA1:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA013.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA014Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA014Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA1:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA014.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA015Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA015Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA1:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA015.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA016Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA016Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA016:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA016.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA017Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA017Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA017:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA017.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA018Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA018Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA018:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA018.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA019Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA019Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA019:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA019.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA020Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA020Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA020:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA020.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA021Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA021Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA021:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA021.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA022Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA022Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA022:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA022.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA023Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA023Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA023:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA023.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA024Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIA024Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIA024:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIA024.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB001Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB001Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB001:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Any Subject can perform any action on any resource.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB002Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB002Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB002:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB002.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB003Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB003Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB003:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB003.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB004Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB004Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB004:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB004.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB005Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB005Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB005:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB005.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB006Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB006Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB006:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB006.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB007Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB007Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB007:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB007.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB008Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB008Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB008:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB008.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB009Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB009Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB009:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB009.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB010Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB010Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB010:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB010.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB011Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB011Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB011:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB011.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB012Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB012Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB012:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB012.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB013Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB013Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB013:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB013.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB014Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB014Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB014:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB014.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB015Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB015Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB015:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB015.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB016Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB016Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB016:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB016.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB017Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB017Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB017:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB017.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB018Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB018Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB018:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB018.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB019Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB019Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB019:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB019.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB020Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB020Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB020:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB020.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB021Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB021Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB021:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB021.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB022Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB022Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB022:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB022.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB023Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB023Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB023:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB023.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB024Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB024Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB024:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB024.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB025Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB025Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB025:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB025.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB026Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB026Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB026:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB026.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB027Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB027Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB027:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB027.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB028Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB028Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB028:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB028.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB029Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB029Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB029:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB029.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB030Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB030Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB030:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB030.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB031Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB031Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB031:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB031.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB032Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB032Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB032:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB032.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB033Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB033Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB033:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB033.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB034Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB034Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB034:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB034.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB035Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB035Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB035:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB035.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB036Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB036Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB036:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB036.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB037Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB037Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB037:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB037.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB038Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB038Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB038:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB038.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB039Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB039Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB039:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB039.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB040Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB040Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB040:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB040.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB041Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB041Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB041:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB041.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB042Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB042Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB042:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB042.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB043Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB043Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB043:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB043.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB044Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB044Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB044:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB044.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB045Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB045Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB045:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB045.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB046Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB046Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB046:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB046.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB047Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB047Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB047:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB047.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB048Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB048Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB048:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB048.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB049Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB049Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB049:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB049.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB050Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB050Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB050:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB050.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB051Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB051Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB051:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB051.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB052Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB052Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB052:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB052.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB053Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB053Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIB053:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIB053.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB300Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB300Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB301Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIB301Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC001Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC001Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC001:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC001.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC002Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC002Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC002:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC002.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC003Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC003Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC003:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC003.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC004Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC004Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC004:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC004.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC005Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC005Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC005:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC005.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC006Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC006Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC006:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC006.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC007Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC007Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC007:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC007.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC008Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC008Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC008:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC008.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC009Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC009Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC009:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC009.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC010Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC010Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC010:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC010.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC011Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC011Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC011:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC011.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC012Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC012Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC012:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC012.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC013Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC013Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC013:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC013.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC014Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC014Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC014:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC014.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC015Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC015Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC015:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC015.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC016Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC016Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC016:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC016.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC017Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC017Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC017:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC017.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC018Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC018Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC018:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC018.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC019Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC019Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC019:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC019.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC020Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC020Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC020:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC020.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC021Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC021Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC021:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC021.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC022Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC022Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC022:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC022.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC024Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC024Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC024:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC024.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC025Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC025Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC025:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC025.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC026Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC026Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC026:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC026.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC027Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC027Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC027:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC027.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC028Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC028Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC028:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC028.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC029Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC029Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC029:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC029.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC030Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC030Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC030:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC030.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC031Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC031Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC031:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC031.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC032Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC032Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC032:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC032.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC033Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC033Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC033:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC033.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC034Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC034Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC034:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC034.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC035Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC035Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC035:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC035.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC036Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC036Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC036:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC036.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC037Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC037Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC037:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC037.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC038Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC038Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC038:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC038.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC039Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC039Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC039:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC039.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC040Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC040Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC040:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC040.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC041Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC041Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC041:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC041.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC042Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC042Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC042:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC042.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC043Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC043Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC043:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC043.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC044Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC044Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC044:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC044.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC045Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC045Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC045:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC045.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC046Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC046Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC046:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC046.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC047Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC047Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC047:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC047.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC048Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC048Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC048:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC048.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC049Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC049Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC049:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC049.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC050Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC050Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC050:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC050.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC051Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC051Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC051:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC051.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC052Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC052Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC052:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC052.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC053Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC053Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC053:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC053.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC056Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC056Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC056:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC056.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC057Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC057Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC057:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC057.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC058Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC058Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC058:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC058.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC059Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC059Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC059:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC059.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC060Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC060Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC060:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC060.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC061Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC061Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC061:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC061.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC062Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC062Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC062:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC062.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC063Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC063Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC063:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC063.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC064Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC064Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC064:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC064.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC065Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC065Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC065:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC065.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC066Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC066Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC066:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC066.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC067Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC067Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC067:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC067.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC068Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC068Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC068:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC068.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC069Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC069Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC069:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC069.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC070Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC070Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC070:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC070.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC071Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC071Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC071:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC071.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC072Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC072Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC072:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC072.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC073Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC073Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC073:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC073.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC074Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC074Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC074:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC074.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC075Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC075Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC075:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC075.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC076Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC076Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC076:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC076.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC077Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC077Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC077:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC077.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC078Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC078Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC078:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC078.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC079Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC079Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC079:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC079.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC080Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC080Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC080:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC080.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC081Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC081Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC081:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC081.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC082Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC082Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC082:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC082.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC083Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC083Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC083:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC083.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC084Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC084Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC084:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC084.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC085Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC085Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC085:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC085.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC086Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC086Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC086:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC086.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC087Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC087Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC087:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC087.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC090Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC090Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC090:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC090.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC091Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC091Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC091:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC091.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC094Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC094Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC094:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC094.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC095Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC095Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC095:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC095.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC096Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC096Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC096:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC096.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC097Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC097Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC097:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC097.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC100Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC100Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC100:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC100.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC101Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC101Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC101:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC101.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC102Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC102Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC102:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC102.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC103Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC103Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC103:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC103.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC104Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC104Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC104:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC104.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC105Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC105Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC105:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC105.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC106Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC106Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC106:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC106.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC107Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC107Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC107:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC107.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC108Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC108Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC108:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC108.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC109Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC109Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC109:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC109.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC110Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC110Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC110:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC110.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC111Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC111Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC111:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC111.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC112Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC112Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC112:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC112.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC113Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC113Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC113:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC113.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC114Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC114Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC114:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC114.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC115Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC115Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC115:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC115.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC116Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC116Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC116:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC116.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC117Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC117Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC117:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC117.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC118Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC118Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC118:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC118.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC119Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC119Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC119:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC119.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC120Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC120Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC120:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC120.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC121Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC121Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC121:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC121.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC122Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC122Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC122:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC122.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC123Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC123Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC123:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC123.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC124Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC124Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC124:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC124.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC125Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC125Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC125:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC125.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC126Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC126Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC126:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC126.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC127Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC127Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC127:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC127.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC128Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC128Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC128:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC128.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC129Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC129Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC129:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC129.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC130Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC130Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC130:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC130.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC131Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC131Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC131:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC131.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC132Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC132Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC132:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC132.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC133Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC133Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC133:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC133.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC134Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC134Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC134:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC134.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC135Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC135Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC135:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC135.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC136Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC136Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC136:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC136.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC137Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC137Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC137:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC137.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC138Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC138Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC138:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC138.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC139Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC139Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC139:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC139.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC140Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC140Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC140:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC140.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC141Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC141Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC141:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC141.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC142Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC142Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC142:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC142.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC143Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC143Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC143:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC143.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC144Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC144Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC144:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC144.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC145Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC145Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC145:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC145.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC146Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC146Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC146:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC146.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC147Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC147Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC147:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC147.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC148Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC148Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC148:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC148.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC149Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC149Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC149:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC149.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC150Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC150Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC150:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC150.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC151Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC151Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC151:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC151.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC152Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC152Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC152:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC152.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC153Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC153Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC153:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC153.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC154Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC154Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC154:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC154.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC155Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC155Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC155:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC155.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC156Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC156Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC156:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC156.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC157Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC157Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC157:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC157.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC158Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC158Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC158:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC158.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC159Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC159Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC159:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC159.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC160Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC160Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC160:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC160.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC161Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC161Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC161:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC161.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC162Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC162Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC162:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC162.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC163Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC163Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC163:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC163.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC164Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC164Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC164:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC164.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC165Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC165Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC165:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC165.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC166Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC166Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC166:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC166.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC167Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC167Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC167:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC167.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC168Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC168Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC168:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC168.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC169Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC169Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC169:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC169.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC170Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC170Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC170:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC170.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC171Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC171Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC171:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC171.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC172Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC172Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC172:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC172.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC173Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC173Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC173:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC173.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC174Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC174Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC174:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC174.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC175Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC175Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC175:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC175.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC176Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC176Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC176:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC176.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC177Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC177Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC177:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC177.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC178Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC178Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC178:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC178.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC179Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC179Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC179:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC179.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC180Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC180Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC180:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC180.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC181Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC181Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC181:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC181.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC182Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC182Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC182:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC182.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC183Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC183Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC183:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC183.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC184Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC184Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC184:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC184.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC185Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC185Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC185:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC185.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC186Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC186Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC186:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC186.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC187Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC187Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC187:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC187.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC188Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC188Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC188:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC188.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC189Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC189Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC189:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC189.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC190Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC190Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC190:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC190.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC191Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC191Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC191:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC191.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC192Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC192Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC192:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC192.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC193Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC193Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC193:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC193.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC194Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC194Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC194:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC194.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC195Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC195Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC195:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC195.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC196Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC196Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC196:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC196.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC197Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC197Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC197:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC197.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC198Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC198Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC198:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC198.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC199Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC199Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC199:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC199.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC200Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC200Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC200:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC200.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC201Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC201Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC201:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC201.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC202Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC202Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC202:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC202.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC203Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC203Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC203:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC203.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC204Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC204Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC204:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC204.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC205Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC205Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC205:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC205.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC206Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC206Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC206:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC206.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC207Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC207Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC207:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC207.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC208Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC208Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC208:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC208.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC209Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC209Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC209:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC209.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC210Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC210Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC210:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC210.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC211Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC211Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC211:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC211.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC212Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC212Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC212:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC212.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC213Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC213Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC213:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC213.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC214Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC214Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC214:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC214.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC215Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC215Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC215:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC215.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC216Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC216Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC216:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC216.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC217Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC217Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC217:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC217.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC218Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC218Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC218:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC218.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC219Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC219Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC219:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC219.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC220Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC220Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC220:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC220.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC221Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC221Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC221:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC221.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC222Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC222Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC222:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC222.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC223Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC223Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC223:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC223.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC224Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC224Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC224:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC224.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC225Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC225Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC225:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC225.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC226Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC226Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC226:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC226.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC227Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC227Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC227:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC227.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC228Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC228Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC228:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC228.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC229Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC229Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC229:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC229.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC230Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC230Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC230:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC230.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC231Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC231Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC231:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC231.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC232Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC232Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC232:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC232.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC300Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC300Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC300:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC301Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC301Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC301:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC302Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC302Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC302:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC303Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC303Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC303:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC310Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC310Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC310:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC311Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC311Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC311:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC312Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC312Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC312:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC313Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC313Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC313:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC320Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC320Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC320:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC321Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC321Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC321:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC322Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC322Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC322:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC323Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC323Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC323:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC330Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC330Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC330:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC331Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC331Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC330:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC332Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC332Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC330:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC333Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC333Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC330:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC334Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC334Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC330:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC335Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC335Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC330:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC340Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC340Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC340:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC341Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC341Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC341:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC342Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC342Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC342:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC343Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC343Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC343:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC344Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC344Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC344:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC345Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC345Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC345:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC346Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC346Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC346:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC347Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC347Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC347:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC348Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC348Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC348:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC349Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC349Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC349:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC350Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC350Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC350:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC350. Test that special value NaN for data type double is handled by both Policy and Request.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC351Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC351Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC351:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC351. Test that special value INF for data type double is handled by Policy and Request.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC352Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC352Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC352:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC352. Test that special value -INF for data type double is handled by Policy and Request.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC353Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC353Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC353:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC353. Test that special value NaN is not the same as special value INF.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC354Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC354Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC354:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC354. Test that special value NaN is not the same as special value INF

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC355Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC355Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC355:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC355. Test that special value NaN is not the same as special value INF

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC356Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC356Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC356:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC357. Test that a numeric value is less than special value INF

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC357Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC357Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC357:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC357. Test that a numeric value is less than special value INF

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC358Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC358Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC358:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC358. Arithmetic on NaN returns NaN.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC359Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIC359Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC359:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC359. Arithmetic on INF returns INF.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID001Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID001Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID001:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID001.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID002Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID002Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID002:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID002.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID003Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID003Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID003:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID004Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID004Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID004:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID005Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID005Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID005:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID005.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID006Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID006Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID007Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID007Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID008Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID008Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID009Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID009Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID009:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID009.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID010Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID010Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID010:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID010.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID011Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID011Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID011:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID011.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID012Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID012Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID012:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID012.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID013Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID013Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID013:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID013.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID014Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID014Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID014:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID014.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID015Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID015Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID015:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID015.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID016Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID016Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID016:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID016.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID017Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID017Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID017:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID017.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID018Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID018Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID018:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID018.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID019Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID019Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID019:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID019.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID020Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID020Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID020:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID020.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID021Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID021Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID021:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID021.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID022Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID022Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID022:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID022.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID023Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID023Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID023:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IID023.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID024Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID024Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID024:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID024.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID025Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID025Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID025:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID025.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID026Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID026Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID026:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID026.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID027Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID027Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID027:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID027.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID028Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID028Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID028:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID028.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID029Policy1.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID029Policy1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID029:policy1" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os     access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         One of two policies for Conformance Test IID029.  NOT APPLICABLE.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID029Policy2.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID029Policy2.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID029:policy2" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy2 for Conformance Test IID029. PERMIT.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID030Policy1.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID030Policy1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID030:policy1" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         One of two policies for Conformance Test IID030.  DENY.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID030Policy2.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID030Policy2.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID029:policy2" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy2 for Conformance Test IID029. PERMIT.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID300Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID300Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID301Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID301Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID301ordered:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID302Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID302Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID302:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID303Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID303Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID303:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID304Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID304Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID304:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID305Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID305Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID305:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID306Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID306Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID307Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID307Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID308Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID308Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID309Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID309Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID310Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID310Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID311Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID311Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID311:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID312Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID312Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID312:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID313Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID313Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID313:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID314Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID314Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID314:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID315Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID315Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID315:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID316Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID316Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID317Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID317Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID318Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID318Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID319Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID319Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID320Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID320Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID330Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID330Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-unless-permit" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID331Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID331Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-unless-permit" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID332Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID332Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID332ordered:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID333Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID333Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID333ordered:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID340Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID340Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-unless-deny" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID341Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID341Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-unless-deny" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID342Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID342Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID342ordered:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID343Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IID343Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID343ordered:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE001Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE001Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIE001:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIE001.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE001PolicySetId1.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE001PolicySetId1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIE001:policyset1" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet1 for Conformance Test IIE001.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE001Policyid1.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE001Policyid1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIE001:policy1" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy1 for Conformance Test IIE001.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE002Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE002Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIE002:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIE002.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE002PolicyId1.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE002PolicyId1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIE002:policy1" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os  access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy1 for Conformance Test IIE002.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE002PolicySetId1.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE002PolicySetId1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIE002:policyset1" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet1 for Conformance Test IIE002.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE003Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE003Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIE003:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIE003.  policy2 is not

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE003PolicyId1.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE003PolicyId1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIE003:policy1" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy1 for Conformance Test IIE003.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE003PolicyId2.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIE003PolicyId2.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIE003:policy2" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy2 for Conformance Test IIE003.  This policy is

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIF300Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIF300Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:md="http://www.medico.com/schemas/record" xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIG006:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIF300.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIF301Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIF301Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:md="http://www.medico.com/schemas/record" xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIG006:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIF301.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIF310Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIF310Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIF311Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIF311Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA001Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA001Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA001.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA002Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA002Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA002:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA002.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA003Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA003Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA003:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA003.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA004Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA004Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA004:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA004.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA005Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA005Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA005:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA005.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA006Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA006Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA006:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA006.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA007Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA007Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA007:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA007.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA008Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA008Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA008:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA008.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA009Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA009Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA009:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA009.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA010Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA010Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA010:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA010.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA011Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA011Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA011:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA011.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA012Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA012Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA012:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA012.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA013Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA013Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA013:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA013.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA014Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA014Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA014:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA014.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA015Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA015Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA015:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA015.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA016Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA016Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA016:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA016.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA017Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA017Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA017:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA017.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA018Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA018Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA018:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA018.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA019Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA019Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA019:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA019.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA020Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA020Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA020:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA020.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA021Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA021Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA021:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA021.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA022Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA022Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA022:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA022.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA023Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA023Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA023:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA023.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA024Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA024Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA024:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA024.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA025Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA025Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA025:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA025.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA026Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA026Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA026:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA026.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA027Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA027Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA027:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA027.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA028Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA028Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA028:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA028.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA030Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA030Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA030:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA030.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA301Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA301Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA301:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA301.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA302Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA302Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA002:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA002.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA303Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA303Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA003:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA003.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA304Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA304Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA004:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA004.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA305Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA305Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA005:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA005.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA306Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA306Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA006:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA006.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA307Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA307Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA007:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA007.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA308Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA308Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA008:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA008.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA309Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA309Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA009:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA009.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA310Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA310Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA010:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA010.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA311Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA311Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA011:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA011.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA312Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA312Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA012:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA012.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA313Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA313Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA013:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA013.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA314Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA314Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA014:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA014.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA315Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA315Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA015:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA015.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA316Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA316Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA016:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA016.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA317Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA317Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA017:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA017.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA318Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA318Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA018:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA018.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA319Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA319Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA019:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA019.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA320Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA320Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA020:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA020.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA321Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA321Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA021:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA021.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA322Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA322Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA022:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA022.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA323Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA323Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA023:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA023.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA324Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA324Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:first-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA024:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA024.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA325Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA325Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA025:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA025.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA326Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA326Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA026:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA026.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA327Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA327Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA027:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA027.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA328Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA328Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:only-one-applicable" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA028:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IIIA028.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA329Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA329Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA001.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA330Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA330Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA330:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA330.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA340Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIA340Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA340:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIIA340.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIC001Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIC001Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIC001:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIC002Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIC002Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIC002:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIC003Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIC003Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIC003:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIE301Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIE301Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIE302Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIE302Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIE302:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIE303Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIE303Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIE303:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF001Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF001Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF002Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF002Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF003Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF003Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF004Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF004Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF005Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF005Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF006Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF006Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF007Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIF007Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG001Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG001Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG002Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG002Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG003Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG003Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG004Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG004Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG005Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG005Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG006Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG006Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG300Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG300Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG301Policy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/IIIG301Policy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,8 +16,7 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
+<PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-deny-overrides" 
 		PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIG301:policyset" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC102dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC102dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC102d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC102d. Deprecated datTimeDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC103dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC103dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC103d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC103d. Deprecated yearMonthDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC104dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC104dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC104d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC104d. Deprecated dayTimeDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC105dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC105dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC105d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC105d. Deprecated yearMonthDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC106dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC106dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC106d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC106d. Deprecated yearMonthDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC107dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC107dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC107d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC107d. Deprecated yearMonthDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC150dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC150dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC150d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC150d. Deprecated dayTimeDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC151dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC151dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC151d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC151d. Deprecated dayTimeDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC152dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC152dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC152d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC152d. Deprecated dayTimeDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC153dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC153dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC153d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC153d. Deprecated dayTimeDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC154dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC154dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC154d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC154d. Deprecated yearMonthDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC155dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC155dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC155d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC155d. Deprecated yearMonthDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC156dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC156dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC156d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC156d. Deprecated yearMonthDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC157dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC157dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC157d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC157d. Deprecated yearMonthDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC164dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC164dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC164d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC165dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC165dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC165d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC166dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC166dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC166d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC170dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC170dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC170f:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC231dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC231dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC231d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC231d. Deprecated dayTimeDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC232dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC232dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC232d:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC232d. Deprecated yearMonthDuration id.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC340dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC340dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC340d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC341dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC341dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC341d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC342dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC342dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC342d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC343dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC343dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC343d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC344dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC344dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC344d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC345dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC345dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC345d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC346dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC346dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC346d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC347dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC347dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC347d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC348dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC348dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC348d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC349dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC349dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC349d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC500dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIC500dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIC006:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os         access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         Policy for Conformance Test IIC500d. test deprecated uri-string-concatenate.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID001dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID001dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID001d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID002dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID002dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID002d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID003dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID003dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID003d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID004dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID004dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID004d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID005dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID005dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID006dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID006dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID007dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID007dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID008dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID008dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID009dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID009dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID009d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID010dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID010dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID010d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID011dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID011dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID011d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID012dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID012dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID012d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID013dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID013dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID014dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID014dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID015dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID015dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID016dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID016dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:permit-overrides" PolicySetId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID016:policyset" Version="1.0" xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:policy:schema:os access_control-xacml-2.0-policy-schema-os.xsd">
     <Description>
         PolicySet for Conformance Test IID016d.  Deprecated Overrides test.

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID300dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID300dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID301dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID301dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID301orderedd:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID302dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID302dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID302d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID304dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID304dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID304d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID305dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID305dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID305d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID306dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID306dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.1:policy-combining-algorithm:ordered-deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID307dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID307dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:3.0:policy-combining-algorithm:ordered-deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID308dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID308dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.1:policy-combining-algorithm:ordered-deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID309dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID309dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.1:policy-combining-algorithm:ordered-deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID310dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID310dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.1:policy-combining-algorithm:ordered-deny-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID311dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID311dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID311d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID313dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID313dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID313d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID314dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID314dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IID314d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID315dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID315dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:II315d:policy" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID316dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID316dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.1:policy-combining-algorithm:ordered-permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID317dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID317dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.1:policy-combining-algorithm:ordered-permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID318dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID318dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.1:policy-combining-algorithm:ordered-permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID319dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID319dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.1:policy-combining-algorithm:ordered-permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID320dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IID320dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <PolicySet xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.1:policy-combining-algorithm:ordered-permit-overrides" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG001dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG001dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG002dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG002dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG003dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG003dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG004dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG004dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG005dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG005dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 

--- a/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG006dPolicy.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/conformance/xacml3.0-ct-v.0.4/xacml3.0-deprecated/IIIG006dPolicy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,8 +16,7 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" 
+<Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
 		xmlns:md="http://www.medico.com/schemas/record" 
 		xmlns:xacml-context="urn:oasis:names:tc:xacml:3.0:context:schema:os" 
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/openaz-xacml-test/src/test/resources/testsets/custom/category/Custom-Category-v1.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/custom/category/Custom-Category-v1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:com:att:xacml:policy:id:4ec39305-37d5-40c4-a614-8a258683b114" Version="1" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable">
     <Description>Test policy for using a custom category.</Description>
     <Target>

--- a/openaz-xacml-test/src/test/resources/testsets/custom/category/xacml.properties
+++ b/openaz-xacml-test/src/test/resources/testsets/custom/category/xacml.properties
@@ -4,7 +4,7 @@
 # Standard API Factories
 #
 xacml.dataTypeFactory=org.apache.openaz.xacml.std.StdDataTypeFactory
-xacml.pdpEngineFactory=org.apache.openaz.xacmlatt.pdp.ATTPDPEngineFactory
+xacml.pdpEngineFactory=org.apache.openaz.xacml.pdp.OpenAZPDPEngineFactory
 xacml.pepEngineFactory=org.apache.openaz.xacml.std.pep.StdEngineFactory
 xacml.pipFinderFactory=org.apache.openaz.xacml.std.pip.StdPIPFinderFactory
 #

--- a/openaz-xacml-test/src/test/resources/testsets/custom/datatype-function/Custom-Datatype-Function-v1.xml
+++ b/openaz-xacml-test/src/test/resources/testsets/custom/datatype-function/Custom-Datatype-Function-v1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:com:att:xacml:policy:id:eca9620b-0f58-4ede-8198-1168862a6133" Version="1" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable">
     <Description>This policy demonstrates the use of a custom datatype and function for that datatype.</Description>
     <Target/>

--- a/openaz-xacml-test/src/test/resources/testsets/custom/datatype-function/results/Response.01.Permit.json
+++ b/openaz-xacml-test/src/test/resources/testsets/custom/datatype-function/results/Response.01.Permit.json
@@ -1,0 +1,10 @@
+{
+  "Response" : [ {
+    "Status" : {
+      "StatusCode" : {
+        "Value" : "urn:oasis:names:tc:xacml:1.0:status:ok"
+      }
+    },
+    "Decision" : "Permit"
+  } ]
+}

--- a/openaz-xacml-test/src/test/resources/testsets/custom/datatype-function/results/Response.02.Deny.json
+++ b/openaz-xacml-test/src/test/resources/testsets/custom/datatype-function/results/Response.02.Deny.json
@@ -1,0 +1,10 @@
+{
+  "Response" : [ {
+    "Status" : {
+      "StatusCode" : {
+        "Value" : "urn:oasis:names:tc:xacml:1.0:status:ok"
+      }
+    },
+    "Decision" : "Deny"
+  } ]
+}

--- a/openaz-xacml-test/src/test/resources/testsets/custom/datatype-function/xacml.properties
+++ b/openaz-xacml-test/src/test/resources/testsets/custom/datatype-function/xacml.properties
@@ -4,13 +4,13 @@
 #
 # Our Customized Factories
 #
-xacml.dataTypeFactory=org.apache.openaz.xacmlatt.pdp.test.custom.CustomDataTypeFactory
-xacml.openaz.functionDefinitionFactory=org.apache.openaz.xacmlatt.pdp.test.custom.CustomFunctionDefinitionFactory
+xacml.dataTypeFactory=org.apache.openaz.xacml.pdp.test.custom.CustomDataTypeFactory
+xacml.openaz.functionDefinitionFactory=org.apache.openaz.xacml.pdp.test.custom.CustomFunctionDefinitionFactory
 
 #
 # Standard API Factories
 #
-xacml.pdpEngineFactory=org.apache.openaz.xacmlatt.pdp.ATTPDPEngineFactory
+xacml.pdpEngineFactory=org.apache.openaz.xacml.pdp.OpenAZPDPEngineFactory
 xacml.pepEngineFactory=org.apache.openaz.xacml.std.pep.StdEngineFactory
 xacml.pipFinderFactory=org.apache.openaz.xacml.std.pip.StdPIPFinderFactory
 #


### PR DESCRIPTION
- Changed references to AT&T class names with OpenAZ ones
- Removed duplicate xml declarations from policy files and updated remaining xml declaration with standalone status from redundant one
