### PR TITLE
Jaxp load xml

### DIFF
--- a/openaz-xacml/src/main/java/org/apache/openaz/xacml/std/jaxp/JaxpRequest.java
+++ b/openaz-xacml/src/main/java/org/apache/openaz/xacml/std/jaxp/JaxpRequest.java
@@ -51,7 +51,6 @@ import org.apache.openaz.xacml.std.dom.DOMStructureException;
 import org.apache.openaz.xacml.std.dom.DOMUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 /**
@@ -60,6 +59,16 @@ import org.xml.sax.SAXException;
  */
 public class JaxpRequest extends StdMutableRequest {
     private static Log logger = LogFactory.getLog(JaxpRequest.class);
+    
+	private static JAXBContext context = null;
+	    
+    private static void init() throws JAXBException {
+        synchronized (JaxpRequest.class) {
+        	if(context == null) {
+        		context = JAXBContext.newInstance(RequestType.class);
+        	}
+        }
+    }
 
     public JaxpRequest() {
     }
@@ -114,19 +123,13 @@ public class JaxpRequest extends StdMutableRequest {
             logger.error("No Document returned parsing \"" + fileXmlRequest.getAbsolutePath() + "\"");
             return null;
         }
-
-        NodeList nodeListRoot = document.getChildNodes();
-        if (nodeListRoot == null || nodeListRoot.getLength() == 0) {
-            logger.warn("No child elements of the XML document");
-            return null;
+        
+        Node nodeRoot = document.getDocumentElement();
+        
+        if(context == null) {
+            init();
         }
-        Node nodeRoot = nodeListRoot.item(0);
-        if (nodeRoot == null || nodeRoot.getNodeType() != Node.ELEMENT_NODE) {
-            logger.warn("Root of the document is not an ELEMENT");
-            return null;
-        }
-
-        JAXBContext context = JAXBContext.newInstance(RequestType.class);
+        
         Unmarshaller unmarshaller = context.createUnmarshaller();
         JAXBElement<RequestType> jaxbElementRequest = unmarshaller.unmarshal(nodeRoot,
                                                                              RequestType.class);

--- a/openaz-xacml/src/main/java/org/apache/openaz/xacml/std/jaxp/JaxpResponse.java
+++ b/openaz-xacml/src/main/java/org/apache/openaz/xacml/std/jaxp/JaxpResponse.java
@@ -50,7 +50,6 @@ import org.apache.openaz.xacml.std.dom.DOMStructureException;
 import org.apache.openaz.xacml.std.dom.DOMUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 /**
@@ -59,7 +58,17 @@ import org.xml.sax.SAXException;
  */
 public class JaxpResponse extends StdMutableResponse {
     private static Log logger = LogFactory.getLog(JaxpResponse.class);
-
+    
+    private static JAXBContext context = null;
+    
+    private static void init() throws JAXBException {
+        synchronized (JaxpRequest.class) {
+        	if(context == null) {
+        		context = JAXBContext.newInstance(ResponseType.class);
+        	}
+        }
+    }
+    
     protected JaxpResponse() {
     }
 
@@ -102,18 +111,12 @@ public class JaxpResponse extends StdMutableResponse {
             return null;
         }
 
-        NodeList nodeListRoot = document.getChildNodes();
-        if (nodeListRoot == null || nodeListRoot.getLength() == 0) {
-            logger.warn("No child elements of the XML document");
-            return null;
-        }
-        Node nodeRoot = nodeListRoot.item(0);
-        if (nodeRoot == null || nodeRoot.getNodeType() != Node.ELEMENT_NODE) {
-            logger.warn("Root of the document is not an ELEMENT");
-            return null;
-        }
+        Node nodeRoot = document.getDocumentElement();
 
-        JAXBContext context = JAXBContext.newInstance(ResponseType.class);
+        if(context == null) {
+            init();
+        }
+        
         Unmarshaller unmarshaller = context.createUnmarshaller();
         JAXBElement<ResponseType> jaxbElementResponse = unmarshaller.unmarshal(nodeRoot,
                                                                                ResponseType.class);

--- a/openaz-xacml/src/main/java/org/apache/openaz/xacml/std/jaxp/JaxpResponse.java
+++ b/openaz-xacml/src/main/java/org/apache/openaz/xacml/std/jaxp/JaxpResponse.java
@@ -50,6 +50,7 @@ import org.apache.openaz.xacml.std.dom.DOMStructureException;
 import org.apache.openaz.xacml.std.dom.DOMUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 /**
@@ -58,17 +59,7 @@ import org.xml.sax.SAXException;
  */
 public class JaxpResponse extends StdMutableResponse {
     private static Log logger = LogFactory.getLog(JaxpResponse.class);
-    
-    private static JAXBContext context = null;
-    
-    private static void init() throws JAXBException {
-        synchronized (JaxpRequest.class) {
-        	if(context == null) {
-        		context = JAXBContext.newInstance(ResponseType.class);
-        	}
-        }
-    }
-    
+
     protected JaxpResponse() {
     }
 
@@ -111,12 +102,18 @@ public class JaxpResponse extends StdMutableResponse {
             return null;
         }
 
-        Node nodeRoot = document.getDocumentElement();
-
-        if(context == null) {
-            init();
+        NodeList nodeListRoot = document.getChildNodes();
+        if (nodeListRoot == null || nodeListRoot.getLength() == 0) {
+            logger.warn("No child elements of the XML document");
+            return null;
         }
-        
+        Node nodeRoot = nodeListRoot.item(0);
+        if (nodeRoot == null || nodeRoot.getNodeType() != Node.ELEMENT_NODE) {
+            logger.warn("Root of the document is not an ELEMENT");
+            return null;
+        }
+
+        JAXBContext context = JAXBContext.newInstance(ResponseType.class);
         Unmarshaller unmarshaller = context.createUnmarshaller();
         JAXBElement<ResponseType> jaxbElementResponse = unmarshaller.unmarshal(nodeRoot,
                                                                                ResponseType.class);


### PR DESCRIPTION
JaxpRequest and JaxpResponse both have a static method "JaxpRequest load(File fileXmlRequest)" to load a xml file to a corresponding object. The load methods uses JAXB to unmarshal the XML.

When using JAXB to unmarshal XML, it's very expensive to create a JaxbContext, so I modified the methods to use a private static attribute to store and re-use a single JaxbContext.

The load method returns null if the XML's first node is a comment node, I fixed that also.
